### PR TITLE
Use maintainers group instead of individuals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
-# Default code owners for all Titan community repositories
+#
+# Code owners do not propagate to all repos, so this only affects the
+# .github repository. But this should be re-created in each of the Titan
+# community repositories.
+#
 
-*   @mcred @eschrock
+*   @titan-data/maintainers


### PR DESCRIPTION
## Issues Addressed

None.

## Proposed Changes

Codeowners has a feature that allows you to specify a (visible) organization team, not just indivudals. Update the canonical CODEOWNERS to reference the organization team instead of the direct list. This will need to be propagated into each repository (potentially via a template repo for new stuff), but important to have it here.

## Testing

None. Has to be done once pushed.