### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-title: 'Bug Report'
+name: 'Bug Report'
 about: Create a report to help us improve
 labels: bug
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-title: 'Feature Request'
+name: 'Feature Request'
 about: Suggest a new idea
 labels: enhancement
 ---


### PR DESCRIPTION
## Issues Addressed

None.

## Proposed Changes

There was a typo in the issue templates, using "title" (default title for new bugs) instead of "name" (name of the template). Without a "name" field, the templates don't work.

## Testing

Compared to files created through github UI.